### PR TITLE
spread followed by optional fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "Validate and format function arguments ( handles types and optionals)",
   "main": "index.js",
   "scripts": {
-    "test": "lab --assert code --threshold 100",
+    "test": "lab --verbose --assert code --threshold 100",
+    "test-no-cov": "lab --verbose --assert code",
+    "test-watch": "nodemon -x npm run test-no-cov",
     "lint": "standard",
     "format": "standard --format"
   },
@@ -37,6 +39,7 @@
   "dependencies": {
     "101": "^1.2.0",
     "compound-subject": "0.0.1",
+    "debug": "^2.2.0",
     "get-prototype-of": "0.0.0",
     "is-capitalized": "^1.0.0",
     "is-class": "0.0.4"

--- a/test/assert-args.unit.js
+++ b/test/assert-args.unit.js
@@ -441,6 +441,32 @@ describe('assert-args', function () {
           })
         })
 
+        describe('followed by optional', function () {
+          var validArgs = [
+            [10],
+            [10, 10],
+            [10, 10, 10],
+            [10, 10, 10, 10]
+          ]
+          var expectedResults = [
+            { foo: [10], bar: undefined },
+            { foo: [10, 10], bar: undefined },
+            { foo: [10, 10, 10], bar: undefined },
+            { foo: [10, 10, 10, 10], bar: undefined }
+          ]
+          validArgs.slice(0, 1).forEach(function (args, i) {
+            // generated test
+            it('should return args if validations pass: ' + i, function (done) {
+              var out = assertArgs(args, {
+                '[...foo]': 'number',
+                '[bar]': 'function'
+              })
+              expect(out).to.deep.equal(expectedResults[i])
+              done()
+            })
+          })
+        })
+
         var invalidArgs = [
           [null],
           [undefined],

--- a/test/assert-args.unit.js
+++ b/test/assert-args.unit.js
@@ -501,6 +501,32 @@ describe('assert-args', function () {
           })
         })
 
+        describe('followed by optional', function () {
+          var validArgs = [
+            [10],
+            [10, 10],
+            [10, 10, 10],
+            [10, 10, 10, 10]
+          ]
+          var expectedResults = [
+            { foo: [10], bar: undefined },
+            { foo: [10, 10], bar: undefined },
+            { foo: [10, 10, 10], bar: undefined },
+            { foo: [10, 10, 10, 10], bar: undefined }
+          ]
+          validArgs.slice(0, 1).forEach(function (args, i) {
+            // generated test
+            it('should return args if validations pass: ' + i, function (done) {
+              var out = assertArgs(args, {
+                '...foo': 'number',
+                '[bar]': 'function'
+              })
+              expect(out).to.deep.equal(expectedResults[i])
+              done()
+            })
+          })
+        })
+
         var invalidArgs = [
           [{}, fn],
           [{}, 10, 'no'],


### PR DESCRIPTION
The following was resulting in errors:

``` js
assertArgs([10, 10, 10], {
  '...foo': 'number',
  '[bar]': 'object'
})
```

Now results in:

``` js
{
  foo: [10, 10, 10]
}
```
